### PR TITLE
Update README with Japanese translation and GithubAction deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 # workspace-sample
 
-This repository is a sample application for investigating proper design methods using the Github workspace. The website displays a 'Hello World' message and is deployable to Firebase Hosting.
+このリポジトリは、Githubワークスペースを使用して適切な設計方法を調査するためのサンプルアプリケーションです。ウェブサイトは「Hello World」メッセージを表示し、Firebase Hostingにデプロイ可能です。
 
-## Deploying to Firebase Hosting
+## Firebase Hostingへのデプロイ
 
-To deploy this website to Firebase Hosting, follow these steps:
+このウェブサイトをFirebase Hostingにデプロイするには、以下の手順に従ってください：
 
-1. Install Firebase CLI by running `npm install -g firebase-tools`.
-2. Initialize Firebase in your project directory by running `firebase init`. Make sure to select 'Hosting' when prompted and specify the public directory that contains your `index.html`.
-3. Deploy your website by running `firebase deploy`.
+1. `npm install -g firebase-tools`を実行してFirebase CLIをインストールします。
+2. プロジェクトディレクトリで`firebase init`を実行してFirebaseを初期化します。プロンプトが表示されたら「Hosting」を選択し、`index.html`を含む公開ディレクトリを指定してください。
+3. `firebase deploy`を実行してウェブサイトをデプロイします。
 
-By following these steps, you will have your 'Hello World' website running and accessible through Firebase Hosting.
+これらの手順に従うことで、「Hello World」ウェブサイトをFirebase Hostingを通じて実行し、アクセス可能になります。
+
+## GithubActionを使用したデプロイ手順
+
+GithubActionを使用してデプロイするには、以下の手順に従ってください：
+
+1. `.github/workflows/firebase-hosting-merge.yml`と`.github/workflows/firebase-hosting-pull-request.yml`の設定を確認します。
+2. GitHubリポジトリの設定に移動し、`Secrets`セクションで必要なシークレットを設定します。これには、`GITHUB_TOKEN`と`FIREBASE_SERVICE_ACCOUNT_WORKSPACE_SAMPLE_E74B2`が含まれます。
+3. マスターブランチにマージすることで自動的にデプロイがトリガーされます（`firebase-hosting-merge.yml`を参照）。また、プルリクエストが作成されると、プレビューデプロイがトリガーされます（`firebase-hosting-pull-request.yml`を参照）。
+
+これらの手順に従うことで、GithubActionを使用してFirebase Hostingにデプロイすることができます。


### PR DESCRIPTION
Updates the README.md file in the `workspace-sample` repository to include deployment instructions in Japanese for both Firebase Hosting and Github Actions.

- **Translates** the existing content about deploying to Firebase Hosting into Japanese, making the instructions accessible to Japanese speakers.
- **Adds** a new section titled "GithubActionを使用したデプロイ手順" that outlines the steps for deploying using Github Actions, including the setup of necessary secrets in the GitHub repository settings.
- **Details** the deployment process using `.github/workflows/firebase-hosting-merge.yml` and `.github/workflows/firebase-hosting-pull-request.yml`, enabling automatic deployment on merges to the master branch and preview deployments for pull requests.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gongnyaa/workspace-sample?shareId=393a2cc3-f8d4-4f1b-b8e8-9153cc9c633a).